### PR TITLE
Clear misleading branching convention guideline

### DIFF
--- a/docs/git/branching-strategy.md
+++ b/docs/git/branching-strategy.md
@@ -20,6 +20,7 @@ sidebar_label: Branching Strategy
 
 #### The following convention should be followed:
 
-* Every branch should be a branch of `dev` and should be merged to `dev` after PR is reviewed
+* Every feature branch should be a branch of `dev` and should be merged to `dev` after PR is reviewed. 
+* The main branches should be created as required and should follow the hierarchy should be `master`<-`uat`<-`qa`<-`dev`.
 * Every feature, task is done in a separate branch <b>named according to the JIRA issue name</b>.
 * Any critical bug after production release is done via hotfix branches. It is branched off from `master` and <b>merged back to master and dev after it’s done</b>. 


### PR DESCRIPTION
This point `Every branch should be a branch of dev and should be merged to dev after PR is reviewed` could be misleading to people as it implies every branch should be derived from `dev`.