### PR TITLE
Changed the "editUrl" to properly match the editing area for documents!

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,7 +69,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/leapfrogtechnology/coding-guidelines/tree/master/',
+            'https://github.com/leapfrogtechnology/coding-guidelines/edit/master/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
I have changed the "**`editUrl`**" to properly match the editing area for different documents.

The official Docusaurus website also uses the same endpoint for [**`editUrl`**](https://github.com/facebook/docusaurus/blob/main/website/docusaurus.config.js#L145-L150).